### PR TITLE
move IEnumACString into base Interop library.

### DIFF
--- a/Source/Tasler.Interop.Shell/AutoComplete/Enums.cs
+++ b/Source/Tasler.Interop.Shell/AutoComplete/Enums.cs
@@ -1,13 +1,6 @@
 
 namespace Tasler.Interop.Shell.AutoComplete;
 
-public enum AutoCompleteOption : uint
-{
-	None            = 0x0000, // No options
-	MostRecentFirst = 0x0001, // Display most recently used items first
-	FirstUnused     = 0x10000,// 0x00010000 through 0xffff0000 are for enumerator specific options (0x0002-0xffff are reserved)
-}
-
 [Flags]
 public enum AutoCompleteOptions : uint
 {

--- a/Source/Tasler.Interop.Shell/AutoComplete/Guids.cs
+++ b/Source/Tasler.Interop.Shell/AutoComplete/Guids.cs
@@ -9,7 +9,6 @@ public static class Guids
 	public const string IID_IAutoComplete            = "00BB2762-6A77-11D0-A535-00C04FD7D062";
 	public const string IID_IAutoComplete2           = "EAC04BC0-3791-11D2-BB95-0060977B464C";
 	public const string IID_ICurrentWorkingDirectory = "91956D21-9276-11D1-921A-006097DF5BD4";
-	public const string IID_IEnumACString            = "8E74C210-CF9D-4eaf-A403-7356428F0A5A";
 	public const string IID_IObjMgr                  = "00BB2761-6A77-11D0-A535-00C04FD7D062";
 	public const string CLSID_ACLCustomMRU           = "6935DB93-21E8-4CCC-BEB9-9FE3C77A297A";    // Custom MRU AutoComplete List                   (IACList, IEnumString)
 	public const string CLSID_ACLHistory             = "00BB2764-6A77-11D0-A535-00C04FD7D062";    // Microsoft History AutoComplete List            (         IEnumString, IEnumACString)
@@ -18,17 +17,16 @@ public static class Guids
 	public const string CLSID_ACLMulti               = "00BB2765-6A77-11D0-A535-00C04FD7D062";    // Microsoft Multiple AutoComplete List Container (IACList, IEnumString, IEnumACString, IObjMgr, IPersist, IPersistFolder)
 	public const string CLSID_AutoComplete           = "00BB2763-6A77-11D0-A535-00C04FD7D062";    // Microsoft AutoComplete                         (         IEnumString, IAutoComplete, IAutoComplete2, IAutoCompleteDropDown, IAccessible, IDispatch)
 
-	public static readonly Guid Guid_IACList                  = new(IID_IACList                 );
-	public static readonly Guid Guid_IACList2                 = new(IID_IACList2                );
-	public static readonly Guid Guid_IAutoComplete            = new(IID_IAutoComplete           );
-	public static readonly Guid Guid_IAutoComplete2           = new(IID_IAutoComplete2          );
-	public static readonly Guid Guid_ICurrentWorkingDirectory = new(IID_ICurrentWorkingDirectory);
-	public static readonly Guid Guid_IEnumACString            = new(IID_IEnumACString           );
-	public static readonly Guid Guid_IObjMgr                  = new(IID_IObjMgr                 );
-	public static readonly Guid Guid_ACLCustomMRU             = new(CLSID_ACLCustomMRU          );
-	public static readonly Guid Guid_ACLHistory               = new(CLSID_ACLHistory            );
-	public static readonly Guid Guid_ACListISF                = new(CLSID_ACListISF             );
-	public static readonly Guid Guid_ACLMRU                   = new(CLSID_ACLMRU                );
-	public static readonly Guid Guid_ACLMulti                 = new(CLSID_ACLMulti              );
-	public static readonly Guid Guid_AutoComplete             = new(CLSID_AutoComplete          );
+	public static Guid Guid_IACList                  => new(IID_IACList                 );
+	public static Guid Guid_IACList2                 => new(IID_IACList2                );
+	public static Guid Guid_IAutoComplete            => new(IID_IAutoComplete           );
+	public static Guid Guid_IAutoComplete2           => new(IID_IAutoComplete2          );
+	public static Guid Guid_ICurrentWorkingDirectory => new(IID_ICurrentWorkingDirectory);
+	public static Guid Guid_IObjMgr                  => new(IID_IObjMgr                 );
+	public static Guid Guid_ACLCustomMRU             => new(CLSID_ACLCustomMRU          );
+	public static Guid Guid_ACLHistory               => new(CLSID_ACLHistory            );
+	public static Guid Guid_ACListISF                => new(CLSID_ACListISF             );
+	public static Guid Guid_ACLMRU                   => new(CLSID_ACLMRU                );
+	public static Guid Guid_ACLMulti                 => new(CLSID_ACLMulti              );
+	public static Guid Guid_AutoComplete             => new(CLSID_AutoComplete          );
 }

--- a/Source/Tasler.Interop.Shell/AutoComplete/Guids.cs
+++ b/Source/Tasler.Interop.Shell/AutoComplete/Guids.cs
@@ -17,16 +17,16 @@ public static class Guids
 	public const string CLSID_ACLMulti               = "00BB2765-6A77-11D0-A535-00C04FD7D062";    // Microsoft Multiple AutoComplete List Container (IACList, IEnumString, IEnumACString, IObjMgr, IPersist, IPersistFolder)
 	public const string CLSID_AutoComplete           = "00BB2763-6A77-11D0-A535-00C04FD7D062";    // Microsoft AutoComplete                         (         IEnumString, IAutoComplete, IAutoComplete2, IAutoCompleteDropDown, IAccessible, IDispatch)
 
-	public static Guid Guid_IACList                  => new(IID_IACList                 );
-	public static Guid Guid_IACList2                 => new(IID_IACList2                );
-	public static Guid Guid_IAutoComplete            => new(IID_IAutoComplete           );
-	public static Guid Guid_IAutoComplete2           => new(IID_IAutoComplete2          );
-	public static Guid Guid_ICurrentWorkingDirectory => new(IID_ICurrentWorkingDirectory);
-	public static Guid Guid_IObjMgr                  => new(IID_IObjMgr                 );
-	public static Guid Guid_ACLCustomMRU             => new(CLSID_ACLCustomMRU          );
-	public static Guid Guid_ACLHistory               => new(CLSID_ACLHistory            );
-	public static Guid Guid_ACListISF                => new(CLSID_ACListISF             );
-	public static Guid Guid_ACLMRU                   => new(CLSID_ACLMRU                );
-	public static Guid Guid_ACLMulti                 => new(CLSID_ACLMulti              );
-	public static Guid Guid_AutoComplete             => new(CLSID_AutoComplete          );
+	public static readonly Guid Guid_IACList                  = new(IID_IACList                 );
+	public static readonly Guid Guid_IACList2                 = new(IID_IACList2                );
+	public static readonly Guid Guid_IAutoComplete            = new(IID_IAutoComplete           );
+	public static readonly Guid Guid_IAutoComplete2           = new(IID_IAutoComplete2          );
+	public static readonly Guid Guid_ICurrentWorkingDirectory = new(IID_ICurrentWorkingDirectory);
+	public static readonly Guid Guid_IObjMgr                  = new(IID_IObjMgr                 );
+	public static readonly Guid Guid_ACLCustomMRU             = new(CLSID_ACLCustomMRU          );
+	public static readonly Guid Guid_ACLHistory               = new(CLSID_ACLHistory            );
+	public static readonly Guid Guid_ACListISF                = new(CLSID_ACListISF             );
+	public static readonly Guid Guid_ACLMRU                   = new(CLSID_ACLMRU                );
+	public static readonly Guid Guid_ACLMulti                 = new(CLSID_ACLMulti              );
+	public static readonly Guid Guid_AutoComplete             = new(CLSID_AutoComplete          );
 }

--- a/Source/Tasler.Interop.Shell/AutoComplete/Interfaces.cs
+++ b/Source/Tasler.Interop.Shell/AutoComplete/Interfaces.cs
@@ -21,34 +21,6 @@ public partial interface IObjMgr
 	void Remove(IEnumString punk);
 }
 
-[Guid(Guids.IID_IEnumACString)]
-[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
-[System.Diagnostics.CodeAnalysis.SuppressMessage("ComInterfaceGenerator", "SYSLIB1230:Specifying 'GeneratedComInterfaceAttribute' on an interface that has a base interface defined in another assembly is not supported", Justification = "Allowed")]
-public partial interface IEnumACString : IEnumString
-{
-	/// <summary>
-	/// Retrieves the next auto-complete string into the provided buffer.
-	/// </summary>
-	/// <param name="pszUr">Buffer that receives the next item string.</param>
-	/// <param name="cchMax">Maximum number of characters the buffer can hold, including the terminating null if applicable.</param>
-	/// <param name="pulSortIndex">Receives the sort index associated with the returned item.</param>
-	/// <returns>An HRESULT indicating success, that no more items are available, or an error code.</returns>
-	[PreserveSig]
-	int NextItem(string pszUr, uint cchMax, out uint pulSortIndex);
-
-	/// <summary>
-/// Sets the enumeration options that control how auto-complete strings are produced and filtered.
-/// </summary>
-/// <param name="dwOptions">Flags specifying the auto-complete enumeration behavior to apply.</param>
-	void SetEnumOptions(AutoCompleteOption dwOptions);
-
-	/// <summary>
-/// Gets the options currently applied to auto-complete string enumeration.
-/// </summary>
-/// <returns>The current <see cref="AutoCompleteOption"/> flags controlling enumeration behavior.</returns>
-	AutoCompleteOption GetEnumOptions();
-}
-
 [Guid(Guids.IID_IACList)]
 [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
 public partial interface IACList

--- a/Source/Tasler.Interop.Shell/Interfaces/IEnumIDList.cs
+++ b/Source/Tasler.Interop.Shell/Interfaces/IEnumIDList.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices.Marshalling;
 
 namespace Tasler.Interop.Shell;
 
-//[System.Diagnostics.CodeAnalysis.SuppressMessage("ComInterfaceGenerator", "SYSLIB1051:Specified type is not supported by source-generated COM", Justification = "It works")]
 [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
 [Guid("000214F2-0000-0000-C000-000000000046")]
 public partial interface IEnumIDList

--- a/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
+++ b/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
@@ -22,11 +22,11 @@ public partial interface IImageList
 
 	void Remove(int i);
 
-	nint GetIcon(int i, uint flags);  // SafeGdiIconOwned
+	nint GetIcon(int i, ImageListDrawFlags flags);  // SafeGdiIconOwned
 
 	IMAGEINFO GetImageInfo(int i);
 
-	void Copy(int iDst, nint punkSrc, int iSrc, uint uFlags);
+	void Copy(int iDst, nint punkSrc, int iSrc, ImageListCopyFlags uFlags);
 
 	void Merge(int i1, nint punk2, int i2, int dx, int dy, ref Guid riid, out nint ppv);
 
@@ -60,7 +60,7 @@ public partial interface IImageList
 
 	void DragShowNolock([MarshalAs(UnmanagedType.Bool)] bool fShow);
 
-	nint GetDragImage(out POINT ppt, out POINT pptHotspot, ref Guid riid);
+	nint GetDragImage(out POINT ppt, out POINT pptHotspot, out Guid riid);
 
 	uint GetItemFlags(int i);
 

--- a/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
+++ b/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
@@ -8,7 +8,7 @@ namespace Tasler.Interop.Shell.Interfaces;
 [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
 public partial interface IImageList
 {
-	void Add(nint hbmImage, nint hbmMask);
+	void Add(/*SafeGdiBitmap*/ nint hbmImage, /*SafeGdiBitmap*/ nint hbmMask);
 
 	void ReplaceIcon(int i, /*SafeGdiIcon*/ nint hIcon);
 
@@ -16,7 +16,7 @@ public partial interface IImageList
 
 	void Replace(int i, nint hbmImage, nint hbmMask);
 
-	void AddMasked(nint hbmImage, COLORREF crMask);
+	void AddMasked(/*SafeGdiBitmap*/ nint hbmImage, COLORREF crMask);
 
 	void Draw(ref IMAGELISTDRAWPARAMS imldp);
 

--- a/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
+++ b/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
@@ -1,0 +1,72 @@
+using System.Runtime.InteropServices;
+using Tasler.Interop.Gdi;
+
+namespace Tasler.Interop.Shell.Interfaces;
+
+[ComImport]
+[Guid("46EB5926-582E-4017-9FDF-E8998DAA0950")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IImageList
+{
+	int Add(IntPtr hbmImage, IntPtr hbmMask);
+
+	int ReplaceIcon(int i, SafeGdiIcon hIcon);
+
+	void SetOverlayImage(int iImage, int iOverlay);
+
+	void Replace(int i, IntPtr hbmImage, IntPtr hbmMask);
+
+	int AddMasked(IntPtr hbmImage, COLORREF crMask);
+
+	void Draw(ref IMAGELISTDRAWPARAMS imldp);
+
+	void Remove(int i);
+
+	SafeGdiIconOwned GetIcon(int i, uint flags);
+
+	IMAGEINFO GetImageInfo(int i);
+
+	void Copy(int iDst, [MarshalAs(UnmanagedType.IUnknown)] object punkSrc, int iSrc, uint uFlags);
+
+	[return: MarshalAs(UnmanagedType.IUnknown, IidParameterIndex = 5)]
+	void Merge(int i1, [MarshalAs(UnmanagedType.IUnknown)] object punk2, int i2, int dx, int dy, ref Guid riid);
+
+	[return: MarshalAs(UnmanagedType.IUnknown, IidParameterIndex = 0)]
+
+	object Clone(ref Guid riid);
+
+	RECT GetImageRect(int i);
+
+	int GetIconSize(out int cx);
+
+	void SetIconSize(int cx, int cy);
+
+	int GetImageCount();
+
+	void SetImageCount(uint uNewCount);
+
+	COLORREF SetBkColor(COLORREF clrBk);
+
+	COLORREF GetBkColor();
+
+	void BeginDrag(int iTrack, int dxHotspot, int dyHotspot);
+
+	void EndDrag();
+
+	void DragEnter(IntPtr IntPtrLock, int x, int y);
+
+	void DragLeave(IntPtr IntPtrLock);
+
+	void DragMove(int x, int y);
+
+	void SetDragCursorImage([MarshalAs(UnmanagedType.IUnknown)] object punk, int iDrag, int dxHotspot, int dyHotspot);
+
+	void DragShowNolock(bool fShow);
+
+	[return: MarshalAs(UnmanagedType.IUnknown, IidParameterIndex = 2)]
+	object GetDragImage(out POINT ppt, out POINT pptHotspot, ref Guid riid);
+
+	uint GetItemFlags(int i);
+
+	int GetOverlayImage(int iOverlay);
+}

--- a/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
+++ b/Source/Tasler.Interop.Shell/Interfaces/IImageList.cs
@@ -1,43 +1,40 @@
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tasler.Interop.Gdi;
 
 namespace Tasler.Interop.Shell.Interfaces;
 
-[ComImport]
 [Guid("46EB5926-582E-4017-9FDF-E8998DAA0950")]
-[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-public interface IImageList
+[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+public partial interface IImageList
 {
-	int Add(IntPtr hbmImage, IntPtr hbmMask);
+	void Add(nint hbmImage, nint hbmMask);
 
-	int ReplaceIcon(int i, SafeGdiIcon hIcon);
+	void ReplaceIcon(int i, /*SafeGdiIcon*/ nint hIcon);
 
 	void SetOverlayImage(int iImage, int iOverlay);
 
-	void Replace(int i, IntPtr hbmImage, IntPtr hbmMask);
+	void Replace(int i, nint hbmImage, nint hbmMask);
 
-	int AddMasked(IntPtr hbmImage, COLORREF crMask);
+	void AddMasked(nint hbmImage, COLORREF crMask);
 
 	void Draw(ref IMAGELISTDRAWPARAMS imldp);
 
 	void Remove(int i);
 
-	SafeGdiIconOwned GetIcon(int i, uint flags);
+	nint GetIcon(int i, uint flags);  // SafeGdiIconOwned
 
 	IMAGEINFO GetImageInfo(int i);
 
-	void Copy(int iDst, [MarshalAs(UnmanagedType.IUnknown)] object punkSrc, int iSrc, uint uFlags);
+	void Copy(int iDst, nint punkSrc, int iSrc, uint uFlags);
 
-	[return: MarshalAs(UnmanagedType.IUnknown, IidParameterIndex = 5)]
-	void Merge(int i1, [MarshalAs(UnmanagedType.IUnknown)] object punk2, int i2, int dx, int dy, ref Guid riid);
+	void Merge(int i1, nint punk2, int i2, int dx, int dy, ref Guid riid, out nint ppv);
 
-	[return: MarshalAs(UnmanagedType.IUnknown, IidParameterIndex = 0)]
-
-	object Clone(ref Guid riid);
+	nint Clone(ref Guid riid);
 
 	RECT GetImageRect(int i);
 
-	int GetIconSize(out int cx);
+	void GetIconSize(out int cx, out int cy);
 
 	void SetIconSize(int cx, int cy);
 
@@ -53,20 +50,19 @@ public interface IImageList
 
 	void EndDrag();
 
-	void DragEnter(IntPtr IntPtrLock, int x, int y);
+	void DragEnter(nint nintLock, int x, int y);
 
-	void DragLeave(IntPtr IntPtrLock);
+	void DragLeave(nint nintLock);
 
 	void DragMove(int x, int y);
 
-	void SetDragCursorImage([MarshalAs(UnmanagedType.IUnknown)] object punk, int iDrag, int dxHotspot, int dyHotspot);
+	void SetDragCursorImage(nint punk, int iDrag, int dxHotspot, int dyHotspot);
 
-	void DragShowNolock(bool fShow);
+	void DragShowNolock([MarshalAs(UnmanagedType.Bool)] bool fShow);
 
-	[return: MarshalAs(UnmanagedType.IUnknown, IidParameterIndex = 2)]
-	object GetDragImage(out POINT ppt, out POINT pptHotspot, ref Guid riid);
+	nint GetDragImage(out POINT ppt, out POINT pptHotspot, ref Guid riid);
 
 	uint GetItemFlags(int i);
 
-	int GetOverlayImage(int iOverlay);
+	void GetOverlayImage(int iOverlay, out int index);
 }

--- a/Source/Tasler.Interop.Shell/Interfaces/IImageList2.cs
+++ b/Source/Tasler.Interop.Shell/Interfaces/IImageList2.cs
@@ -1,0 +1,41 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Tasler.Interop.Shell.Interfaces;
+
+[Guid("192B9D83-50FC-457B-90A0-2B82A8B5DAE1")]
+[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+public partial interface IImageList2 : IImageList
+{
+	void Resize(int cxNewIconSize, int cyNewIconSize);
+
+	void GetOriginalSize(int iImage, uint dwFlags, out int pcx, out int pcy);
+
+	void SetOriginalSize(int iImage, int cx, int cy);
+
+	void SetCallback(nint punk);
+
+	nint GetCallback(ref Guid riid);
+
+	void ForceImagePresent(int iImage, ImageListForceImagePresent dwFlags);
+
+	void DiscardImages(int iFirstImage, int iLastImage, uint dwFlags);
+
+	void PreloadImages(ref IMAGELISTDRAWPARAMS pimldp);
+
+	void GetStatistics(ref IMAGELISTSTATS pils);
+
+	/// <summary>
+	///
+	/// </summary>
+	/// <param name="cx"></param>
+	/// <param name="cy"></param>
+	/// <param name="flags"></param>
+	/// <param name="cInitial"></param>
+	/// <param name="cGrow"></param>
+	void Initialize(int cx, int cy, ImageListCreationFlags flags, int cInitial, int cGrow);
+
+	void Replace2(int index, /*SafeGdiBitmap*/ nint hbmImage, /*SafeGdiBitmap*/ nint hbmMask, nint pUnknown, ImageListReplaceFlags flags);
+
+	void ReplaceFromImageList(int i, IImageList pil, int iSrc, nint punk, uint dwFlags = 0);
+}

--- a/Source/Tasler.Interop.Shell/ShellApi.NativeMethods.cs
+++ b/Source/Tasler.Interop.Shell/ShellApi.NativeMethods.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using CommunityToolkit.Diagnostics;
 using Tasler.Interop.Com;
 using Tasler.Interop.User;
 
@@ -9,124 +8,6 @@ namespace Tasler.Interop.Shell;
 
 public static partial class ShellApi
 {
-	/// <summary>
-	/// Obtain the system shell's desktop folder.
-	/// </summary>
-	/// <returns>The desktop shell folder exposed as an <see cref="IShellFolder2"/> instance.</returns>
-	/// <exception cref="System.Runtime.InteropServices.COMException">Thrown when the native SHGetDesktopFolder call fails; the HRESULT is converted to a managed exception.</exception>
-	public static IShellFolder2 GetDesktopFolder()
-	{
-		IShellFolder folder = null!;
-		var hr = NativeMethods.SHGetDesktopFolder(out folder);
-		if (hr < 0)
-			Marshal.ThrowExceptionForHR(hr);
-
-		return (IShellFolder2)folder;
-	}
-
-	/// <summary>
-	/// Creates a managed wrapper for the shell item identified by the specified PIDL and returns it as the requested interface type.
-	/// </summary>
-	/// <param name="pidl">The item ID list (PIDL) that identifies the shell item to create.</param>
-	/// <typeparam name="TInterface">The COM interface type to cast the created shell item to.</typeparam>
-	/// <returns>An instance of <typeparamref name="TInterface"/> representing the shell item identified by <paramref name="pidl"/>.</returns>
-	/// <exception cref="System.Runtime.InteropServices.COMException">Thrown when the underlying shell API returns a failure HRESULT.</exception>
-	public static TInterface CreateItemFromIDList<TInterface>(ItemIdList pidl)
-	{
-		var iid = typeof(TInterface).GUID;
-		int hr = NativeMethods.SHCreateItemFromIDList(pidl.Handle, ref iid, out nint value);
-		if (hr < 0)
-			Marshal.ThrowExceptionForHR(hr);
-
-		return (TInterface)ComApi.Wrappers.GetOrCreateObjectForComInstance(value, CreateObjectFlags.Unwrap);
-	}
-
-	/// <summary>
-	/// Creates an IShellItem of the requested interface for a child PIDL using the specified parent folder and parent PIDL.
-	/// </summary>
-	/// <param name="parentItemIdList">Absolute or parent PIDL that identifies the parent folder.</param>
-	/// <param name="parentShellFolder">The parent IShellFolder to use when creating the child item.</param>
-	/// <param name="childItemIdList">The child (relative) PIDL to create as an IShellItem under the parent.</param>
-	/// <returns>An instance of <typeparamref name="TInterface"/> representing the created shell item.</returns>
-	/// <exception cref="System.Exception">Thrown when the native SHCreateItemWithParent call returns a failing HRESULT; a corresponding COM exception is propagated.</exception>
-	public static TInterface CreateItemWithParent<TInterface>(
-		ItemIdList parentItemIdList,
-		IShellFolder parentShellFolder,
-		ChildItemIdList childItemIdList)
-		where TInterface : IShellItem
-	{
-		var iid = typeof(TInterface).GUID;
-		var hr = NativeMethods.SHCreateItemWithParent(parentItemIdList.Handle, parentShellFolder, childItemIdList.Handle, ref iid, out IShellItem value);
-		if (hr < 0)
-			Marshal.ThrowExceptionForHR(hr);
-
-		return (TInterface)value;
-	}
-
-	/// <summary>
-	/// Gets the parse-name (the parsing/display path used by the shell) for the folder identified by the given item ID list.
-	/// </summary>
-	/// <param name="folderIdList">A PIDL that identifies the folder whose parse-name to retrieve.</param>
-	/// <returns>The parse-name for the specified folder, or <c>null</c> if no parse-name is available.</returns>
-	public static string GetFolderParseName(ItemIdList folderIdList)
-	{
-		ChildItemIdList folderInParentIdList;
-		using (ItemIdList folderParentIdList = folderIdList.GetParentAndChild(out folderInParentIdList))
-		using (folderInParentIdList)
-		{
-			Guid iid = typeof(IShellFolder).GUID;
-			IShellFolder folderParent = (IShellFolder)ShellApi.GetDesktopFolder();
-			var folderParentPointer = folderParent.BindToObject(folderParentIdList.Handle, null, ref iid);
-			if (!folderParentIdList.IsEmpty)
-				ComApi.Wrappers.GetOrCreateObjectForComInstance(folderParentPointer, CreateObjectFlags.Unwrap);
-
-			using StrRet strRet = folderParent.GetDisplayNameOf(folderInParentIdList.Handle, SHGDNF.ForParsing);
-			return strRet.Value ?? strRet.GetValue(folderInParentIdList);
-		}
-	}
-
-	/// <summary>
-	/// Retrieve the display name for the specified absolute PIDL using the given SIGDN format.
-	/// </summary>
-	/// <param name="pidlAbsolute">Absolute PIDL identifying the shell item.</param>
-	/// <param name="sigdnName">The display name type to retrieve.</param>
-	/// <returns>The display name for the specified PIDL.</returns>
-	/// <exception cref="System.Runtime.InteropServices.COMException">Thrown when the underlying Shell API call fails.</exception>
-	public static string GetNameFromIDList(ItemIdList pidlAbsolute, SIGDN sigdnName)
-	{
-		int hr = NativeMethods.SHGetNameFromIDList(pidlAbsolute.Handle, sigdnName, out var namePtr);
-		if (hr < 0)
-			Marshal.ThrowExceptionForHR(hr);
-		return new SafeCoTaskMemString { Handle = namePtr }.Value;
-	}
-
-	/// <summary>
-	/// Uses ShellExecuteW to open the specified URI in the system's default web browser.
-	/// </summary>
-	/// <param name="uri">
-	/// The URI to open. This must be an absolute URL using http, https, file, or mailto protocols.
-	/// </param>
-	public static void OpenUriInDefaultBrowser(string uri)
-	{
-		if (string.IsNullOrWhiteSpace(uri))
-			throw new ArgumentException(Properties.Resources.ArgumentExceptionNonEmptyAbsoluteUriRequired, nameof(uri));
-
-		if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsedUri) ||
-			(parsedUri.Scheme != Uri.UriSchemeHttp
-			&& parsedUri.Scheme != Uri.UriSchemeHttps
-			&& parsedUri.Scheme != Uri.UriSchemeFile
-			&& parsedUri.Scheme != Uri.UriSchemeMailto))
-		{
-			throw new ArgumentException(Properties.Resources.ArgumentExceptionOnlySpecificAbsoluteUrisSupported, nameof(uri));
-		}
-
-		var result = NativeMethods.ShellExecuteW(SafeHwnd.Null, "open", uri, null, null, SW.ShowNormal);
-		if (result <= 32)
-			throw new Win32Exception();
-	}
-
-	//[System.Diagnostics.CodeAnalysis.SuppressMessage("ComInterfaceGenerator", "SYSLIB1051:Specified type is not supported by source-generated COM", Justification = "It works")]
-	//[System.Diagnostics.CodeAnalysis.SuppressMessage("LibraryImportGenerator", "SYSLIB1052:Specified configuration is not supported by source-generated P/Invokes.", Justification = "<Pending>")]
 	public static partial class NativeMethods
 	{
 		private const string Shell32 = "shell32.dll";
@@ -234,6 +115,12 @@ public static partial class ShellApi
 			string? lpParameters,
 			string? lpDirectory,
 			SW nShowCmd);
+
+		[LibraryImport(Shell32, StringMarshalling = StringMarshalling.Utf16)]
+		public static partial nint SHGetFileInfo(string path, uint fileAttributes, ref SHFILEINFOW sfi, uint cbFileInfo, SHGFI flags);
+
+		[LibraryImport(Shell32)]
+		public static partial int SHGetImageList(SHIL iImageList, ref Guid iid, out nint imageList);
 	}
 }
 

--- a/Source/Tasler.Interop.Shell/ShellApi.NativeMethods.cs
+++ b/Source/Tasler.Interop.Shell/ShellApi.NativeMethods.cs
@@ -1,7 +1,5 @@
-using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using Tasler.Interop.Com;
 using Tasler.Interop.User;
 
 namespace Tasler.Interop.Shell;

--- a/Source/Tasler.Interop.Shell/ShellApiExtensions.cs
+++ b/Source/Tasler.Interop.Shell/ShellApiExtensions.cs
@@ -1,9 +1,137 @@
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Tasler.Interop.Com;
-using static Tasler.Interop.Shell.PropertyKeys;
+using Tasler.Interop.Shell.Interfaces;
+using Tasler.Interop.User;
 
 namespace Tasler.Interop.Shell;
 
 public static partial class ShellApi
 {
+	/// <summary>
+	/// Obtain the system shell's desktop folder.
+	/// </summary>
+	/// <returns>The desktop shell folder exposed as an <see cref="IShellFolder2"/> instance.</returns>
+	/// <exception cref="System.Runtime.InteropServices.COMException">Thrown when the native SHGetDesktopFolder call fails; the HRESULT is converted to a managed exception.</exception>
+	public static IShellFolder2 GetDesktopFolder()
+	{
+		IShellFolder folder = null!;
+		var hr = NativeMethods.SHGetDesktopFolder(out folder);
+		if (hr < 0)
+			Marshal.ThrowExceptionForHR(hr);
+
+		return (IShellFolder2)folder;
+	}
+
+	/// <summary>
+	/// Creates a managed wrapper for the shell item identified by the specified PIDL and returns it as the requested interface type.
+	/// </summary>
+	/// <param name="pidl">The item ID list (PIDL) that identifies the shell item to create.</param>
+	/// <typeparam name="TInterface">The COM interface type to cast the created shell item to.</typeparam>
+	/// <returns>An instance of <typeparamref name="TInterface"/> representing the shell item identified by <paramref name="pidl"/>.</returns>
+	/// <exception cref="System.Runtime.InteropServices.COMException">Thrown when the underlying shell API returns a failure HRESULT.</exception>
+	public static TInterface CreateItemFromIDList<TInterface>(ItemIdList pidl)
+	{
+		var iid = typeof(TInterface).GUID;
+		int hr = NativeMethods.SHCreateItemFromIDList(pidl.Handle, ref iid, out nint value);
+		if (hr < 0)
+			Marshal.ThrowExceptionForHR(hr);
+
+		return (TInterface)ComApi.Wrappers.GetOrCreateObjectForComInstance(value, CreateObjectFlags.Unwrap);
+	}
+
+	/// <summary>
+	/// Creates an IShellItem of the requested interface for a child PIDL using the specified parent folder and parent PIDL.
+	/// </summary>
+	/// <param name="parentItemIdList">Absolute or parent PIDL that identifies the parent folder.</param>
+	/// <param name="parentShellFolder">The parent IShellFolder to use when creating the child item.</param>
+	/// <param name="childItemIdList">The child (relative) PIDL to create as an IShellItem under the parent.</param>
+	/// <returns>An instance of <typeparamref name="TInterface"/> representing the created shell item.</returns>
+	/// <exception cref="System.Exception">Thrown when the native SHCreateItemWithParent call returns a failing HRESULT; a corresponding COM exception is propagated.</exception>
+	public static TInterface CreateItemWithParent<TInterface>(
+		ItemIdList parentItemIdList,
+		IShellFolder parentShellFolder,
+		ChildItemIdList childItemIdList)
+		where TInterface : IShellItem
+	{
+		var iid = typeof(TInterface).GUID;
+		var hr = NativeMethods.SHCreateItemWithParent(parentItemIdList.Handle, parentShellFolder, childItemIdList.Handle, ref iid, out IShellItem value);
+		if (hr < 0)
+			Marshal.ThrowExceptionForHR(hr);
+
+		return (TInterface)value;
+	}
+
+	/// <summary>
+	/// Gets the parse-name (the parsing/display path used by the shell) for the folder identified by the given item ID list.
+	/// </summary>
+	/// <param name="folderIdList">A PIDL that identifies the folder whose parse-name to retrieve.</param>
+	/// <returns>The parse-name for the specified folder, or <c>null</c> if no parse-name is available.</returns>
+	public static string GetFolderParseName(ItemIdList folderIdList)
+	{
+		ChildItemIdList folderInParentIdList;
+		using (ItemIdList folderParentIdList = folderIdList.GetParentAndChild(out folderInParentIdList))
+		using (folderInParentIdList)
+		{
+			Guid iid = typeof(IShellFolder).GUID;
+			IShellFolder folderParent = (IShellFolder)ShellApi.GetDesktopFolder();
+			var folderParentPointer = folderParent.BindToObject(folderParentIdList.Handle, null, ref iid);
+			if (!folderParentIdList.IsEmpty)
+				ComApi.Wrappers.GetOrCreateObjectForComInstance(folderParentPointer, CreateObjectFlags.Unwrap);
+
+			using StrRet strRet = folderParent.GetDisplayNameOf(folderInParentIdList.Handle, SHGDNF.ForParsing);
+			return strRet.Value ?? strRet.GetValue(folderInParentIdList);
+		}
+	}
+
+	/// <summary>
+	/// Retrieve the display name for the specified absolute PIDL using the given SIGDN format.
+	/// </summary>
+	/// <param name="pidlAbsolute">Absolute PIDL identifying the shell item.</param>
+	/// <param name="sigdnName">The display name type to retrieve.</param>
+	/// <returns>The display name for the specified PIDL.</returns>
+	/// <exception cref="System.Runtime.InteropServices.COMException">Thrown when the underlying Shell API call fails.</exception>
+	public static string GetNameFromIDList(ItemIdList pidlAbsolute, SIGDN sigdnName)
+	{
+		int hr = NativeMethods.SHGetNameFromIDList(pidlAbsolute.Handle, sigdnName, out var namePtr);
+		if (hr < 0)
+			Marshal.ThrowExceptionForHR(hr);
+		return new SafeCoTaskMemString { Handle = namePtr }.Value;
+	}
+
+	/// <summary>
+	/// Uses ShellExecuteW to open the specified URI in the system's default web browser.
+	/// </summary>
+	/// <param name="uri">
+	/// The URI to open. This must be an absolute URL using http, https, file, or mailto protocols.
+	/// </param>
+	public static void OpenUriInDefaultBrowser(string uri)
+	{
+		if (string.IsNullOrWhiteSpace(uri))
+			throw new ArgumentException(Properties.Resources.ArgumentExceptionNonEmptyAbsoluteUriRequired, nameof(uri));
+
+		if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsedUri) ||
+			(parsedUri.Scheme != Uri.UriSchemeHttp
+			&& parsedUri.Scheme != Uri.UriSchemeHttps
+			&& parsedUri.Scheme != Uri.UriSchemeFile
+			&& parsedUri.Scheme != Uri.UriSchemeMailto))
+		{
+			throw new ArgumentException(Properties.Resources.ArgumentExceptionOnlySpecificAbsoluteUrisSupported, nameof(uri));
+		}
+
+		var result = NativeMethods.ShellExecuteW(SafeHwnd.Null, "open", uri, null, null, SW.ShowNormal);
+		if (result <= 32)
+			throw new Win32Exception();
+	}
+
+	public static IImageList SHGetImageList(SHIL iImageList)
+	{
+		var iid = typeof(IImageList).GUID;
+		nint imageList;
+		int hr = NativeMethods.SHGetImageList(iImageList, ref iid, out imageList);
+		if (hr < 0)
+			Marshal.ThrowExceptionForHR(hr);
+
+		return (IImageList)ComApi.Wrappers.GetOrCreateObjectForComInstance(imageList, CreateObjectFlags.Unwrap);
+	}
 }

--- a/Source/Tasler.Interop.Shell/ShellApiExtensions.cs
+++ b/Source/Tasler.Interop.Shell/ShellApiExtensions.cs
@@ -75,9 +75,12 @@ public static partial class ShellApi
 		{
 			Guid iid = typeof(IShellFolder).GUID;
 			IShellFolder folderParent = (IShellFolder)ShellApi.GetDesktopFolder();
-			var folderParentPointer = folderParent.BindToObject(folderParentIdList.Handle, null, ref iid);
+
 			if (!folderParentIdList.IsEmpty)
-				ComApi.Wrappers.GetOrCreateObjectForComInstance(folderParentPointer, CreateObjectFlags.Unwrap);
+			{
+				var folderParentPointer = folderParent.BindToObject(folderParentIdList.Handle, null, ref iid);
+				folderParent = (IShellFolder)ComApi.Wrappers.GetOrCreateObjectForComInstance(folderParentPointer, CreateObjectFlags.Unwrap);
+			}
 
 			using StrRet strRet = folderParent.GetDisplayNameOf(folderInParentIdList.Handle, SHGDNF.ForParsing);
 			return strRet.Value ?? strRet.GetValue(folderInParentIdList);
@@ -96,7 +99,8 @@ public static partial class ShellApi
 		int hr = NativeMethods.SHGetNameFromIDList(pidlAbsolute.Handle, sigdnName, out var namePtr);
 		if (hr < 0)
 			Marshal.ThrowExceptionForHR(hr);
-		return new SafeCoTaskMemString { Handle = namePtr }.Value;
+		using var name = new SafeCoTaskMemString { Handle = namePtr };
+		return name.Value;
 	}
 
 	/// <summary>

--- a/Source/Tasler.Interop.Shell/ShellEnums.cs
+++ b/Source/Tasler.Interop.Shell/ShellEnums.cs
@@ -56,7 +56,7 @@ public enum SHGFI : uint
 	Selected          = 0x000010000,
 	/// <summary>get only specified attributes</summary>
 	AttrSpecified     = 0x000020000,
-	/// <summary></summary>
+	/// <summary>get large icon (default)</summary
 	LargeIcon         = 0x000000000,
 	/// <summary>get small icon</summary>
 	SmallIcon         = 0x000000001,

--- a/Source/Tasler.Interop.Shell/ShellEnums.cs
+++ b/Source/Tasler.Interop.Shell/ShellEnums.cs
@@ -1,0 +1,89 @@
+
+namespace Tasler.Interop.Shell;
+
+
+[Flags]
+public enum SFGAO : uint
+{
+	CanCopy         = 0x00000001, // Objects can be copied    (0x1)
+	CanMove         = 0x00000002, // Objects can be moved     (0x2)
+	CanLink         = 0x00000004, // Objects can be linked    (0x4)
+	CanRename       = 0x00000010, // Objects can be renamed
+	CanDelete       = 0x00000020, // Objects can be deleted
+	HasPropSheet    = 0x00000040, // Objects have property sheets
+	DropTarget      = 0x00000100, // Objects are drop target
+	CapabilityMask  = 0x00000177,
+	Link            = 0x00010000, // Shortcut (link)
+	Share           = 0x00020000, // shared
+	ReadOnly        = 0x00040000, // read-only
+	Ghosted         = 0x00080000, // ghosted icon
+	Hidden          = 0x00080000, // hidden object
+	DisplayAttrMask = 0x000F0000,
+	FileSysAncestor = 0x10000000, // It contains file system folder
+	Folder          = 0x20000000, // It's a folder.
+	FileSystem      = 0x40000000, // is a file system thing (file/folder/root)
+	HasSubfolder    = 0x80000000, // Expandable in the map pane
+	ContentsMask    = 0x80000000,
+	Validate        = 0x01000000, // invalidate cached information
+	Removable       = 0x02000000, // is this removeable media?
+	Compressed      = 0x04000000, // Object is compressed (use alt color)
+	Browsable       = 0x08000000, // is in-place browsable
+	NonEnumerated   = 0x00100000, // is a non-enumerated object
+	NewContent      = 0x00200000, // should show bold in explorer tree
+	CanMoniker      = 0x00400000, // can create monikers for its objects
+}
+
+[Flags]
+public enum SHGFI : uint
+{
+	/// <summary>get icon</summary>
+	Icon              = 0x000000100,
+	/// <summary>get display name</summary>
+	DisplayName       = 0x000000200,
+	/// <summary>get type name</summary>
+	TypeName          = 0x000000400,
+	/// <summary>get attributes</summary>
+	Attributes        = 0x000000800,
+	/// <summary>get icon location</summary>
+	IconLocation      = 0x000001000,
+	/// <summary>return exe type</summary>
+	ExeType           = 0x000002000,
+	/// <summary>get system icon index</summary>
+	SysIconIndex      = 0x000004000,
+	/// <summary>put a link overlay on icon</summary>
+	LinkOverlay       = 0x000008000,
+	/// <summary>show icon in selected state</summary>
+	Selected          = 0x000010000,
+	/// <summary>get only specified attributes</summary>
+	AttrSpecified     = 0x000020000,
+	/// <summary></summary>
+	LargeIcon         = 0x000000000,
+	/// <summary>get small icon</summary>
+	SmallIcon         = 0x000000001,
+	/// <summary>get open icon</summary>
+	OpenIcon          = 0x000000002,
+	/// <summary>get shell size icon</summary>
+	ShellIconSize     = 0x000000004,
+	/// <summary>pszPath is a pidl</summary>
+	Pidl              = 0x000000008,
+	/// <summary>use passed dwFileAttribute</summary>
+	UseFileAttributes = 0x000000010,
+	/// <summary>apply the appropriate overlays</summary>
+	AddOverlays       = 0x000000020,
+	/// <summary>Get the index of the overlay in the upper 8 bits of the iIcon</summary>
+	OverlayIndex      = 0x000000040,
+}
+
+public enum SHIL
+{
+	/// <summary>normally 32x32</summary>
+	Large      = 0,
+	/// <summary>normally 16x16</summary>
+	Small = 1,
+	/// <summary>normally 48x48?</summary>
+	ExtraLarge = 2,
+	/// <summary>like SHIL_SMALL, but tracks system small icon metric correctly</summary>
+	SysSmall = 3,
+	/// <summary>normally 256x256</summary>
+	Jumbo = 4,
+}

--- a/Source/Tasler.Interop.Shell/ShellEnums.cs
+++ b/Source/Tasler.Interop.Shell/ShellEnums.cs
@@ -220,3 +220,86 @@ public enum ImageListCopyFlags : uint
 	/// </summary>
 	Swap = 1,
 }
+
+/// <summary>
+/// Used in the <see cref="IImageList2.ForceImagePresent"/> method.
+/// </summary>
+public enum ImageListForceImagePresent
+{
+	/// <summary>Always get the image(can be slow).</summary>
+	P_ALWAYS = 0x00000000,
+
+	/// <summary>Only get if on standby.</summary>
+	P_FROMSTANDBY = 0x00000001,
+}
+
+[Flags]
+public enum ImageListCreationFlags : uint
+{
+	/// <summery>Use a mask. The image list contains two bitmaps, one of which is a monochrome bitmap used as a mask.If this value is not included, the image list contains only one bitmap.</summery>
+	Mask = 0x00000001,
+
+	/// <summery>Use the default behavior if none of the other ILC_COLORx flags is specified.Typically, the default is ILC_COLOR4, but for older display drivers, the default is ILC_COLORDDB.</summery>
+	Color = 0x00000000,
+
+	/// <summery>Use a device-dependent bitmap.</summery>
+	Colorddb = 0x000000FE,
+
+	/// <summery>Use a 4-bit (16-color) device-independent bitmap(DIB) section as the bitmap for the image list.</summery>
+	Color4 = 0x00000004,
+
+	/// <summery>Use an 8-bit DIB section.The colors used for the color table are the same colors as the halftone palette.</summery>
+	Color8 = 0x00000008,
+
+	/// <summery>Use a 16-bit (32/64k-color) DIB section.</summery>
+	Color16 = 0x00000010,
+
+	/// <summery>Use a 24-bit DIB section.</summery>
+	Color24 = 0x00000018,
+
+	/// <summery>Use a 32-bit DIB section.</summery>
+	Color32 = 0x00000020,
+
+	/// <summery>Not implemented.</summery>
+	Palette = 0x00000800,
+
+	/// <summery>Mirror the icons contained, if the process is mirrored</summery>
+	Mirror = 0x00002000,
+
+	/// <summery>Causes the mirroring code to mirror each item when inserting a set of images, versus the whole strip.</summery>
+	Peritemmirror = 0x00008000,
+
+	/// <summery>Windows Vista and later. Imagelist should accept smaller than set images and apply original size based on image added.</summery>
+	Originalsize = 0x00010000,
+
+	/// <summery>Windows Vista and later. Reserved.</summery>
+	Highqualityscale = 0x00020000,
+}
+
+[Flags]
+public enum ImageListReplaceFlags : uint
+{
+	/// <summary>Horizontally align to left.</summary>
+	HorizontalLeft = 0x0000,
+
+	/// <summary>Horizontally center.</summary>
+	HorizontalCenter = 0x0001,
+
+	/// <summary>Horizontally align to right.</summary>
+	HorizontalRight = 0x0002,
+
+	/// <summary>Vertically align to top.</summary>
+	VerticalTop = 0x0000,
+
+	/// <summary>Vertically align to center.</summary>
+	VerticalCenter = 0x0010,
+
+	/// <summary>Vertically align to bottom.</summary>
+	VerticalBottom = 0x0020,
+
+	/// <summary>Do nothing.</summary>
+	ScaleClip = 0x0000,
+
+	/// <summary>Scale.</summary>
+	ScaleAspectRatio = 0x0100,
+}

--- a/Source/Tasler.Interop.Shell/ShellEnums.cs
+++ b/Source/Tasler.Interop.Shell/ShellEnums.cs
@@ -16,7 +16,7 @@ public enum SFGAO : uint
 	Link            = 0x00010000, // Shortcut (link)
 	Share           = 0x00020000, // shared
 	ReadOnly        = 0x00040000, // read-only
-	Ghosted         = 0x00080000, // ghosted icon
+	Ghosted         = 0x00008000, // ghosted icon
 	Hidden          = 0x00080000, // hidden object
 	DisplayAttrMask = 0x000F0000,
 	FileSysAncestor = 0x10000000, // It contains file system folder

--- a/Source/Tasler.Interop.Shell/ShellEnums.cs
+++ b/Source/Tasler.Interop.Shell/ShellEnums.cs
@@ -87,3 +87,136 @@ public enum SHIL
 	/// <summary>normally 256x256</summary>
 	Jumbo = 4,
 }
+
+[Flags]
+public enum ImageListDrawFlags : uint
+{
+	/// <summary>
+	/// Draws the image using the background color for the image list. If the background color is
+	/// the CLR_NONE value, the image is drawn transparently using the mask.
+	/// </summary>
+	Normal = 0x00000000,
+
+	/// <summary>
+	/// Draws the image transparently using the mask, regardless of the background color. This value
+	/// has no effect if the image list does not contain a mask.
+	/// </summary>
+	Transparent = 0x00000001,
+
+	/// <summary>
+	/// Draws the image, blending 25 percent with the blend color specified by rgbFg. This value has
+	/// no effect if the image list does not contain a mask.
+	/// </summary>
+	Blend25 = 0x00000002,
+
+	/// <summary>
+	/// Same as ILD_BLEND25.
+	/// </summary>
+	Focus = 0x00000002,
+
+	/// <summary>
+	/// Draws the image, blending 50 percent with the blend color specified by rgbFg. This value has
+	/// no effect if the image list does not contain a mask.
+	/// </summary>
+	Blend50 = 0x00000004,
+
+	/// <summary>
+	/// Same as ILD_BLEND50.
+	/// </summary>
+	Selected = 0x00000004,
+
+	/// <summary>
+	/// Same as ILD_BLEND50.
+	/// </summary>
+	Blend = 0x00000004,
+
+	/// <summary>
+	/// Draws the mask.
+	/// </summary>
+	Mask = 0x00000010,
+
+	/// <summary>
+	/// If the overlay does not require a mask to be drawn, set this flag.
+	/// </summary>
+	Image = 0x00000020,
+
+	/// <summary>
+	/// Draws the image using the raster operation code specified by the dwRop member.
+	/// </summary>
+	Rop = 0x00000040,
+
+	/// <summary>
+	/// To extract the overlay image from the fStyle member, use the logical AND to combine fStyle
+	/// with the ILD_OVERLAYMASK value.
+	/// </summary>
+	OverlayMask = 0x00000F00,
+
+	/// <summary>
+	/// Preserves the alpha channel in the destination.
+	/// </summary>
+	PreserveAlpha = 0x00001000,
+
+	/// <summary>
+	/// Causes the image to be scaled to cx, cy instead of being clipped.
+	/// </summary>
+	Scale = 0x00002000,
+
+	/// <summary>
+	/// Scales the image to the current dpi of the display.
+	/// </summary>
+	DpiU= 0x00004000,
+
+	/// <summary>
+	/// Windows Vista and later. Draw the image if it is available in the cache. Do not extract it
+	/// automatically.The called draw method returns E_PENDING to the calling component, which should
+	/// then take an alternative action, such as, provide another image and queue a background task
+	/// to force the image to be loaded via ForceImagePresent using the ILFIP_ALWAYS flag.The
+	/// Async flag then prevents the extraction operation from blocking the current thread and is
+	/// especially important if a draw method is called from the user interface (UI) thread.
+	/// </summary>
+	Async = 0x00008000,
+}
+
+[Flags]
+public enum ImageListStateFlags : uint
+{
+	/// <summary>The image state is not modified.</summary>
+	Normal = 0x00000000,
+
+	/// <summary>Not supported.</summary>
+	Glow = 0x00000001,
+
+	/// <summary>Not supported.</summary>
+	Shadow = 0x00000002,
+
+	/// <summary>
+	/// Reduces the color saturation of the icon to grayscale. This only affects 32bpp images.
+	/// </summary>
+	Saturate = 0x00000004,
+
+	/// <summary>
+	/// Alpha blends the icon. Alpha blending controls the transparency level of an icon, according
+	/// to the value of its alpha channel. The value of the alpha channel is indicated by the frame
+	/// member in the IMAGELISTDRAWPARAMS method. The alpha channel can be from 0 to 255, with 0
+	/// being completely transparent, and 255 being completely opaque.
+	/// </summary>
+	Alpha = 0x00000008,
+}
+
+/// <summary>
+/// Used in the <see cref="IImageList.Copy"/> methodd.
+/// </summary>
+[Flags]
+public enum ImageListCopyFlags : uint
+{
+	/// <summary>
+	/// The source image is copied to the destination image's index. This operation results in
+	/// multiple instances of a given image.
+	/// </summary>
+	Move = 0,
+
+	/// <summary>
+	/// The source and destination images exchange positions within the image list.
+	/// </summary>
+	Swap = 1,
+}

--- a/Source/Tasler.Interop.Shell/ShellStructs.cs
+++ b/Source/Tasler.Interop.Shell/ShellStructs.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Tasler.SuppressMessage;
+
+namespace Tasler.Interop.Shell;
+
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
+public struct SHFILEINFOW
+{
+	public nint hIcon;
+	public int iIcon;
+	public SFGAO attributes;
+	public CharBuffer262 displayName;
+	public CharBuffer82 typeName;
+};
+
+[StructLayout(LayoutKind.Sequential, Pack = 2, CharSet = CharSet.Unicode)]
+public struct CharBuffer262
+{
+	public char C00, C01, C02, C03, C04, C05, C06, C07, C08, C09, C0A, C0B, C0C, C0D, C0E, C0F;
+	public char C10, C11, C12, C13, C14, C15, C16, C17, C18, C19, C1A, C1B, C1C, C1D, C1E, C1F;
+	public char C20, C21, C22, C23, C24, C25, C26, C27, C28, C29, C2A, C2B, C2C, C2D, C2E, C2F;
+	public char C30, C31, C32, C33, C34, C35, C36, C37, C38, C39, C3A, C3B, C3C, C3D, C3E, C3F;
+	public char C40, C41, C42, C43, C44, C45, C46, C47, C48, C49, C4A, C4B, C4C, C4D, C4E, C4F;
+	public char C50, C51, C52, C53, C54, C55, C56, C57, C58, C59, C5A, C5B, C5C, C5D, C5E, C5F;
+	public char C60, C61, C62, C63, C64, C65, C66, C67, C68, C69, C6A, C6B, C6C, C6D, C6E, C6F;
+	public char C70, C71, C72, C73, C74, C75, C76, C77, C78, C79, C7A, C7B, C7C, C7D, C7E, C7F;
+	public char C80, C81, C82, C83, C84, C85, C86, C87, C88, C89, C8A, C8B, C8C, C8D, C8E, C8F;
+	public char C90, C91, C92, C93, C94, C95, C96, C97, C98, C99, C9A, C9B, C9C, C9D, C9E, C9F;
+	public char CA0, CA1, CA2, CA3, CA4, CA5, CA6, CA7, CA8, CA9, CAA, CAB, CAC, CAD, CAE, CAF;
+	public char CB0, CB1, CB2, CB3, CB4, CB5, CB6, CB7, CB8, CB9, CBA, CBB, CBC, CBD, CBE, CBF;
+	public char CC0, CC1, CC2, CC3, CC4, CC5, CC6, CC7, CC8, CC9, CCA, CCB, CCC, CCD, CCE, CCF;
+	public char CD0, CD1, CD2, CD3, CD4, CD5, CD6, CD7, CD8, CD9, CDA, CDB, CDC, CDD, CDE, CDF;
+	public char CE0, CE1, CE2, CE3, CE4, CE5, CE6, CE7, CE8, CE9, CEA, CEB, CEC, CED, CEE, CEF;
+	public char CF0, CF1, CF2, CF3, CF4, CF5, CF6, CF7, CF8, CF9, CFA, CFB, CFC, CFD, CFE, CFF;
+	public char C100, C101, C102, C103, C104, C105;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 2, CharSet = CharSet.Unicode)]
+public struct CharBuffer82
+{
+	public char C00, C01, C02, C03, C04, C05, C06, C07, C08, C09, C0A, C0B, C0C, C0D, C0E, C0F;
+	public char C10, C11, C12, C13, C14, C15, C16, C17, C18, C19, C1A, C1B, C1C, C1D, C1E, C1F;
+	public char C20, C21, C22, C23, C24, C25, C26, C27, C28, C29, C2A, C2B, C2C, C2D, C2E, C2F;
+	public char C30, C31, C32, C33, C34, C35, C36, C37, C38, C39, C3A, C3B, C3C, C3D, C3E, C3F;
+	public char C40, C41, C42, C43, C44, C45, C46, C47, C48, C49, C4A, C4B, C4C, C4D, C4E, C4F;
+	public char C50, C51, C52, C53, C54, C55, C56, C57, C58, C59, C5A, C5B, C5C, C5D, C5E, C5F;
+	public char C60, C61, C62, C63, C64, C65, C66, C67, C68, C69, C6A, C6B, C6C, C6D, C6E, C6F;
+	public char C70, C71, C72, C73, C74, C75, C76, C77, C78, C79, C7A, C7B, C7C, C7D, C7E, C7F;
+	public char C80;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
+public struct RECT
+{
+	public int left;
+	public int top;
+	public int right;
+	public int bottom;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
+public struct POINT
+{
+	public int left;
+	public int top;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
+public struct COLORREF
+{
+	public uint value;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
+public struct IMAGEINFO
+{
+	nint hbmImage;
+	nint hbmMask;
+	int Unused1;
+	int Unused2;
+	RECT rcImage;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
+public struct IMAGELISTDRAWPARAMS
+{
+	uint cbSize;
+	nint himl;
+	int i;
+	nint hdcDst;
+	int x;
+	int y;
+	int cx;
+	int cy;
+	int xBitmap;        // x offest from the upperleft of bitmap
+	int yBitmap;        // y offset from the upperleft of bitmap
+	COLORREF rgbBk;
+	COLORREF rgbFg;
+	uint fStyle;
+	uint dwRop;
+	uint fState;
+	uint Frame;
+	COLORREF crEffect;
+}

--- a/Source/Tasler.Interop.Shell/ShellStructs.cs
+++ b/Source/Tasler.Interop.Shell/ShellStructs.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using Tasler.Extensions;
 using Tasler.Interop.Gdi;
 using Tasler.SuppressMessage;
 
@@ -31,7 +32,7 @@ public struct IMAGEINFO
 [SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
 public struct IMAGELISTDRAWPARAMS
 {
-	public uint cbSize;
+	private int cbSize = IMAGELISTDRAWPARAMS.SizeOf;
 	public nint himl;
 	public int i;
 	public nint hdcDst;
@@ -43,9 +44,11 @@ public struct IMAGELISTDRAWPARAMS
 	public int yBitmap;        // y offset from the upperleft of bitmap
 	public COLORREF rgbBk;
 	public COLORREF rgbFg;
-	public uint fStyle;
-	public uint dwRop;
-	public uint fState;
+	public ImageListDrawFlags fStyle;
+	public ROP3 dwRop;
+	public ImageListStateFlags fState;
 	public uint Frame;
 	public COLORREF crEffect;
+
+	public IMAGELISTDRAWPARAMS() { }
 }

--- a/Source/Tasler.Interop.Shell/ShellStructs.cs
+++ b/Source/Tasler.Interop.Shell/ShellStructs.cs
@@ -12,76 +12,40 @@ public struct SHFILEINFOW
 	public nint hIcon;
 	public int iIcon;
 	public SFGAO attributes;
-	public CharBuffer262 displayName;
-	public CharBuffer82 typeName;
+	public unsafe fixed char displayName[260];
+	public unsafe fixed char typeName[80];
 };
-
-[StructLayout(LayoutKind.Sequential, Pack = 2, CharSet = CharSet.Unicode)]
-public struct CharBuffer262
-{
-	public char C00, C01, C02, C03, C04, C05, C06, C07, C08, C09, C0A, C0B, C0C, C0D, C0E, C0F;
-	public char C10, C11, C12, C13, C14, C15, C16, C17, C18, C19, C1A, C1B, C1C, C1D, C1E, C1F;
-	public char C20, C21, C22, C23, C24, C25, C26, C27, C28, C29, C2A, C2B, C2C, C2D, C2E, C2F;
-	public char C30, C31, C32, C33, C34, C35, C36, C37, C38, C39, C3A, C3B, C3C, C3D, C3E, C3F;
-	public char C40, C41, C42, C43, C44, C45, C46, C47, C48, C49, C4A, C4B, C4C, C4D, C4E, C4F;
-	public char C50, C51, C52, C53, C54, C55, C56, C57, C58, C59, C5A, C5B, C5C, C5D, C5E, C5F;
-	public char C60, C61, C62, C63, C64, C65, C66, C67, C68, C69, C6A, C6B, C6C, C6D, C6E, C6F;
-	public char C70, C71, C72, C73, C74, C75, C76, C77, C78, C79, C7A, C7B, C7C, C7D, C7E, C7F;
-	public char C80, C81, C82, C83, C84, C85, C86, C87, C88, C89, C8A, C8B, C8C, C8D, C8E, C8F;
-	public char C90, C91, C92, C93, C94, C95, C96, C97, C98, C99, C9A, C9B, C9C, C9D, C9E, C9F;
-	public char CA0, CA1, CA2, CA3, CA4, CA5, CA6, CA7, CA8, CA9, CAA, CAB, CAC, CAD, CAE, CAF;
-	public char CB0, CB1, CB2, CB3, CB4, CB5, CB6, CB7, CB8, CB9, CBA, CBB, CBC, CBD, CBE, CBF;
-	public char CC0, CC1, CC2, CC3, CC4, CC5, CC6, CC7, CC8, CC9, CCA, CCB, CCC, CCD, CCE, CCF;
-	public char CD0, CD1, CD2, CD3, CD4, CD5, CD6, CD7, CD8, CD9, CDA, CDB, CDC, CDD, CDE, CDF;
-	public char CE0, CE1, CE2, CE3, CE4, CE5, CE6, CE7, CE8, CE9, CEA, CEB, CEC, CED, CEE, CEF;
-	public char CF0, CF1, CF2, CF3, CF4, CF5, CF6, CF7, CF8, CF9, CFA, CFB, CFC, CFD, CFE, CFF;
-	public char C100, C101, C102, C103, C104, C105;
-}
-
-[StructLayout(LayoutKind.Sequential, Pack = 2, CharSet = CharSet.Unicode)]
-public struct CharBuffer82
-{
-	public char C00, C01, C02, C03, C04, C05, C06, C07, C08, C09, C0A, C0B, C0C, C0D, C0E, C0F;
-	public char C10, C11, C12, C13, C14, C15, C16, C17, C18, C19, C1A, C1B, C1C, C1D, C1E, C1F;
-	public char C20, C21, C22, C23, C24, C25, C26, C27, C28, C29, C2A, C2B, C2C, C2D, C2E, C2F;
-	public char C30, C31, C32, C33, C34, C35, C36, C37, C38, C39, C3A, C3B, C3C, C3D, C3E, C3F;
-	public char C40, C41, C42, C43, C44, C45, C46, C47, C48, C49, C4A, C4B, C4C, C4D, C4E, C4F;
-	public char C50, C51, C52, C53, C54, C55, C56, C57, C58, C59, C5A, C5B, C5C, C5D, C5E, C5F;
-	public char C60, C61, C62, C63, C64, C65, C66, C67, C68, C69, C6A, C6B, C6C, C6D, C6E, C6F;
-	public char C70, C71, C72, C73, C74, C75, C76, C77, C78, C79, C7A, C7B, C7C, C7D, C7E, C7F;
-	public char C80;
-}
 
 [StructLayout(LayoutKind.Sequential)]
 [SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
 public struct IMAGEINFO
 {
-	nint hbmImage;
-	nint hbmMask;
-	int Unused1;
-	int Unused2;
-	RECT rcImage;
+	public nint hbmImage;
+	public nint hbmMask;
+	public int Unused1;
+	public int Unused2;
+	public RECT rcImage;
 }
 
 [StructLayout(LayoutKind.Sequential)]
 [SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
 public struct IMAGELISTDRAWPARAMS
 {
-	uint cbSize;
-	nint himl;
-	int i;
-	nint hdcDst;
-	int x;
-	int y;
-	int cx;
-	int cy;
-	int xBitmap;        // x offest from the upperleft of bitmap
-	int yBitmap;        // y offset from the upperleft of bitmap
-	COLORREF rgbBk;
-	COLORREF rgbFg;
-	uint fStyle;
-	uint dwRop;
-	uint fState;
-	uint Frame;
-	COLORREF crEffect;
+	public uint cbSize;
+	public nint himl;
+	public int i;
+	public nint hdcDst;
+	public int x;
+	public int y;
+	public int cx;
+	public int cy;
+	public int xBitmap;        // x offest from the upperleft of bitmap
+	public int yBitmap;        // y offset from the upperleft of bitmap
+	public COLORREF rgbBk;
+	public COLORREF rgbFg;
+	public uint fStyle;
+	public uint dwRop;
+	public uint fState;
+	public uint Frame;
+	public COLORREF crEffect;
 }

--- a/Source/Tasler.Interop.Shell/ShellStructs.cs
+++ b/Source/Tasler.Interop.Shell/ShellStructs.cs
@@ -52,3 +52,12 @@ public struct IMAGELISTDRAWPARAMS
 
 	public IMAGELISTDRAWPARAMS() { }
 }
+
+[StructLayout(LayoutKind.Sequential)]
+public struct IMAGELISTSTATS
+{
+	public uint SizeInBytes;
+	public int AllocatedCount;
+	public int UsedCount;
+	public int StandbyCount;
+}

--- a/Source/Tasler.Interop.Shell/ShellStructs.cs
+++ b/Source/Tasler.Interop.Shell/ShellStructs.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using Tasler.Interop.Gdi;
 using Tasler.SuppressMessage;
 
 namespace Tasler.Interop.Shell;
@@ -49,31 +50,6 @@ public struct CharBuffer82
 	public char C60, C61, C62, C63, C64, C65, C66, C67, C68, C69, C6A, C6B, C6C, C6D, C6E, C6F;
 	public char C70, C71, C72, C73, C74, C75, C76, C77, C78, C79, C7A, C7B, C7C, C7D, C7E, C7F;
 	public char C80;
-}
-
-[StructLayout(LayoutKind.Sequential)]
-[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
-public struct RECT
-{
-	public int left;
-	public int top;
-	public int right;
-	public int bottom;
-}
-
-[StructLayout(LayoutKind.Sequential)]
-[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
-public struct POINT
-{
-	public int left;
-	public int top;
-}
-
-[StructLayout(LayoutKind.Sequential)]
-[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
-public struct COLORREF
-{
-	public uint value;
 }
 
 [StructLayout(LayoutKind.Sequential)]

--- a/Source/Tasler.Interop.Shell/ShellStructs.cs
+++ b/Source/Tasler.Interop.Shell/ShellStructs.cs
@@ -32,7 +32,7 @@ public struct IMAGEINFO
 [SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
 public struct IMAGELISTDRAWPARAMS
 {
-	private int cbSize = IMAGELISTDRAWPARAMS.SizeOf;
+	public int cbSize = IMAGELISTDRAWPARAMS.SizeOf;
 	public nint himl;
 	public int i;
 	public nint hdcDst;
@@ -40,7 +40,7 @@ public struct IMAGELISTDRAWPARAMS
 	public int y;
 	public int cx;
 	public int cy;
-	public int xBitmap;        // x offest from the upperleft of bitmap
+	public int xBitmap;        // x offset from the upperleft of bitmap
 	public int yBitmap;        // y offset from the upperleft of bitmap
 	public COLORREF rgbBk;
 	public COLORREF rgbFg;
@@ -54,10 +54,11 @@ public struct IMAGELISTDRAWPARAMS
 }
 
 [StructLayout(LayoutKind.Sequential)]
+[SuppressMessage(Category.Style, CheckId.IDE1006_NamingStyles, Justification = Justification.NamingStyles)]
 public struct IMAGELISTSTATS
 {
-	public uint SizeInBytes;
-	public int AllocatedCount;
-	public int UsedCount;
-	public int StandbyCount;
+	public int cbSize;
+	public int cAllocated;
+	public int cUsed;
+	public int cStandby;
 }

--- a/Source/Tasler.Interop.Shell/Tasler.Interop.Shell.csproj
+++ b/Source/Tasler.Interop.Shell/Tasler.Interop.Shell.csproj
@@ -13,6 +13,8 @@
 		<Platforms>AnyCPU;arm64;x64;x86</Platforms>
 		<Description>Windows native dotnet interop framework for shell functionality.</Description>
 		<Title>$(AssemblyName)</Title>
+
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Source/Tasler.Interop/Com/Interfaces/IEnumACString.cs
+++ b/Source/Tasler.Interop/Com/Interfaces/IEnumACString.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Tasler.Interop.Com;
+
+namespace Tasler.Interop.Shell;
+
+public static class Guids
+{
+	public const string IID_IEnumACString = "8E74C210-CF9D-4eaf-A403-7356428F0A5A";
+	public static Guid Guid_IEnumACString => new(IID_IEnumACString);
+}
+
+public enum AutoCompleteOption : uint
+{
+	None            = 0x0000, // No options
+	MostRecentFirst = 0x0001, // Display most recently used items first
+	FirstUnused     = 0x10000,// 0x00010000 through 0xffff0000 are for enumerator specific options (0x0002-0xffff are reserved)
+}
+
+[Guid(Guids.IID_IEnumACString)]
+[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+public partial interface IEnumACString : IEnumString
+{
+	/// <summary>
+	/// Retrieves the next auto-complete string into the provided buffer.
+	/// </summary>
+	/// <param name="pszUr">Buffer that receives the next item string.</param>
+	/// <param name="cchMax">Maximum number of characters the buffer can hold, including the terminating null if applicable.</param>
+	/// <param name="pulSortIndex">Receives the sort index associated with the returned item.</param>
+	/// <returns>An HRESULT indicating success, that no more items are available, or an error code.</returns>
+	[PreserveSig]
+	int NextItem(
+		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I2, SizeParamIndex = 1)]
+		[Out] char[] pszUr,
+		uint cchMax,
+		out uint pulSortIndex);
+
+	/// <summary>
+	/// Sets the enumeration options that control how auto-complete strings are produced and filtered.
+	/// </summary>
+	/// <param name="dwOptions">Flags specifying the auto-complete enumeration behavior to apply.</param>
+	void SetEnumOptions(AutoCompleteOption dwOptions);
+
+	/// <summary>
+	/// Gets the options currently applied to auto-complete string enumeration.
+	/// </summary>
+	/// <returns>The current <see cref="AutoCompleteOption"/> flags controlling enumeration behavior.</returns>
+	AutoCompleteOption GetEnumOptions();
+}
+

--- a/Source/Tasler.Interop/Com/Interfaces/IEnumACString.cs
+++ b/Source/Tasler.Interop/Com/Interfaces/IEnumACString.cs
@@ -31,7 +31,7 @@ public partial interface IEnumACString : IEnumString
 	[PreserveSig]
 	int NextItem(
 		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I2, SizeParamIndex = 1)]
-		[Out] char[] pszUr,
+		[Out] char[] pszUrl,
 		uint cchMax,
 		out uint pulSortIndex);
 

--- a/Source/Tasler.Interop/SuppressMessage.cs
+++ b/Source/Tasler.Interop/SuppressMessage.cs
@@ -1,0 +1,17 @@
+
+namespace Tasler.SuppressMessage;
+
+internal static class Justification
+{
+	public const string NamingStyles = "Using the same casing as the native fields.";
+}
+
+internal static class Category
+{
+	public const string Style = nameof(Style);
+}
+
+internal static class CheckId
+{
+	public const string IDE1006_NamingStyles = "IDE1006:Naming Styles";
+}

--- a/Source/Tasler.UI.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Tasler.UI.Wpf/Properties/AssemblyInfo.cs
@@ -21,6 +21,7 @@ using Tasler.Windows;
 [assembly: XmlnsDefinition(XmlNamespace.Tasler, "Tasler.Windows.Converters")]
 [assembly: XmlnsDefinition(XmlNamespace.Tasler, "Tasler.Windows.Extensions")]
 [assembly: XmlnsDefinition(XmlNamespace.Tasler, "Tasler.Windows.Markup")]
+[assembly: XmlnsDefinition(XmlNamespace.Tasler, "Tasler.Windows.Model")]
 
 [assembly: InternalsVisibleTo("Tasler.Windows.Input")]
 [assembly: InternalsVisibleTo("Tasler.Configuration")]


### PR DESCRIPTION
In addition to the change listed in the PR title, this change also rearranges some things. I moved the Shell interop code that was only in the IconViewer repo. I moved it into the common library, Tasler.Interop.Shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native image-list support and rich shell helpers: icon/image retrieval, overlays, drag‑and‑drop image facilities, and opening URIs in the default browser.

* **Refactor**
  * Consolidated and restructured shell interop surface with explicit enums/structs and dedicated helper wrappers.

* **Chores**
  * Removed obsolete interop declarations; added small build/emitter and analyzer support; added XAML namespace mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->